### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 ftfy
+imageio
+ipywidgets
 regex
 tqdm
 googletrans==3.1.0a0


### PR DESCRIPTION
After following the README install instructions, `clip_fft.py` still didn't work because imageio and ipywidgets weren't installed. This fixes that.